### PR TITLE
Refactor: Migrate testing framework from Mocha/Chai/Sinon to Jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "type": "module",
   "scripts": {
-    "test": "mocha test/**/*.test.js",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "start": "node server.js"
   },
   "keywords": [
@@ -16,9 +16,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "chai": "^5.2.0",
-    "jsdom": "^24.0.0",
-    "mocha": "^11.6.0",
-    "sinon": "^20.0.0"
+    "jest": "^29.7.0",
+    "jsdom": "^24.0.0"
   }
 }

--- a/test/models/Category.test.js
+++ b/test/models/Category.test.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import Category from '../../models/Category.js';
 
 describe('Category Model', () => {
@@ -6,7 +5,7 @@ describe('Category Model', () => {
         it('should create a category and assign the name', () => {
             const categoryData = { name: 'Electronics' };
             const category = new Category(categoryData);
-            expect(category.name).to.equal('Electronics');
+            expect(category.name).toBe('Electronics');
         });
 
         it('should trim whitespace from the category name if any (behavior not specified, but good to test)', () => {
@@ -15,19 +14,19 @@ describe('Category Model', () => {
             // For now, testing current behavior.
             const categoryData = { name: '  Camping Gear  ' };
             const category = new Category(categoryData);
-            expect(category.name).to.equal('  Camping Gear  ');
+            expect(category.name).toBe('  Camping Gear  ');
             // If trimming is desired, Category model constructor should be: this.name = name.trim();
         });
 
         it('should handle empty or undefined names (current behavior is to assign them as is)', () => {
             const category1 = new Category({ name: '' });
-            expect(category1.name).to.equal('');
+            expect(category1.name).toBe('');
 
             const category2 = new Category({ name: undefined });
-            expect(category2.name).to.be.undefined;
+            expect(category2.name).toBeUndefined();
 
             const category3 = new Category({}); // name is undefined
-            expect(category3.name).to.be.undefined;
+            expect(category3.name).toBeUndefined();
         });
     });
 });

--- a/test/models/Item.test.js
+++ b/test/models/Item.test.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import Item from '../../models/Item.js';
 
 describe('Item Model', () => {
@@ -7,17 +6,17 @@ describe('Item Model', () => {
             const itemData = { id: '1', name: 'Test Item', weight: 100 };
             const item = new Item(itemData);
 
-            expect(item.id).to.equal('1');
-            expect(item.name).to.equal('Test Item');
-            expect(item.weight).to.equal(100);
-            expect(item.brand).to.equal('');
-            expect(item.category).to.equal('');
-            expect(item.tags).to.deep.equal([]);
-            expect(item.capacity).to.equal('');
-            expect(item.imageUrl).to.equal('');
-            expect(item.isConsumable).to.be.false;
-            expect(item.packIds).to.deep.equal([]);
-            expect(item.packed).to.be.false;
+            expect(item.id).toBe('1');
+            expect(item.name).toBe('Test Item');
+            expect(item.weight).toBe(100);
+            expect(item.brand).toBe('');
+            expect(item.category).toBe('');
+            expect(item.tags).toEqual([]);
+            expect(item.capacity).toBe('');
+            expect(item.imageUrl).toBe('');
+            expect(item.isConsumable).toBe(false);
+            expect(item.packIds).toEqual([]);
+            expect(item.packed).toBe(false);
         });
 
         it('should correctly assign all provided values', () => {
@@ -36,76 +35,76 @@ describe('Item Model', () => {
             };
             const item = new Item(itemData);
 
-            expect(item.id).to.equal('2');
-            expect(item.name).to.equal('Full Item');
-            expect(item.weight).to.equal(250);
-            expect(item.brand).to.equal('BrandX');
-            expect(item.category).to.equal('CategoryA');
-            expect(item.tags).to.deep.equal(['tag1', 'tag2']);
-            expect(item.capacity).to.equal('Large');
-            expect(item.imageUrl).to.equal('http://example.com/image.png');
-            expect(item.isConsumable).to.be.true;
-            expect(item.packIds).to.deep.equal(['pack1', 'pack2']);
-            expect(item.packed).to.be.true;
+            expect(item.id).toBe('2');
+            expect(item.name).toBe('Full Item');
+            expect(item.weight).toBe(250);
+            expect(item.brand).toBe('BrandX');
+            expect(item.category).toBe('CategoryA');
+            expect(item.tags).toEqual(['tag1', 'tag2']);
+            expect(item.capacity).toBe('Large');
+            expect(item.imageUrl).toBe('http://example.com/image.png');
+            expect(item.isConsumable).toBe(true);
+            expect(item.packIds).toEqual(['pack1', 'pack2']);
+            expect(item.packed).toBe(true);
         });
 
         it('should parse weight to float, defaulting to 0 if invalid', () => {
             const item1 = new Item({ id: '3', name: 'Valid Weight', weight: '150.5' });
-            expect(item1.weight).to.equal(150.5);
+            expect(item1.weight).toBe(150.5);
 
             const item2 = new Item({ id: '4', name: 'Invalid Weight', weight: 'abc' });
-            expect(item2.weight).to.equal(0);
+            expect(item2.weight).toBe(0);
 
             const item3 = new Item({ id: '5', name: 'Missing Weight', weight: undefined });
-            expect(item3.weight).to.equal(0);
+            expect(item3.weight).toBe(0);
         });
 
         it('should parse tags string to array, or keep array, or default to empty array', () => {
             const item1 = new Item({ id: '6', name: 'Tags String', weight: 10, tags: ' tagA , tagB  ' });
-            expect(item1.tags).to.deep.equal(['tagA', 'tagB']);
+            expect(item1.tags).toEqual(['tagA', 'tagB']);
 
             const item2 = new Item({ id: '7', name: 'Tags Array', weight: 10, tags: ['tagC', 'tagD'] });
-            expect(item2.tags).to.deep.equal(['tagC', 'tagD']);
+            expect(item2.tags).toEqual(['tagC', 'tagD']);
 
             const item3 = new Item({ id: '8', name: 'Tags Empty String', weight: 10, tags: '  ' });
-            expect(item3.tags).to.deep.equal([]);
+            expect(item3.tags).toEqual([]);
 
             const item4 = new Item({ id: '9', name: 'Tags Undefined', weight: 10, tags: undefined });
-            expect(item4.tags).to.deep.equal([]);
+            expect(item4.tags).toEqual([]);
 
             const item5 = new Item({ id: '10', name: 'Tags Null', weight: 10, tags: null });
-            expect(item5.tags).to.deep.equal([]);
+            expect(item5.tags).toEqual([]);
         });
 
         it('should handle boolean conversions for isConsumable and packed', () => {
             const item1 = new Item({ id: '11', name: 'Consumable True', weight: 10, isConsumable: true });
-            expect(item1.isConsumable).to.be.true;
+            expect(item1.isConsumable).toBe(true);
 
             const item2 = new Item({ id: '12', name: 'Consumable False', weight: 10, isConsumable: false });
-            expect(item2.isConsumable).to.be.false;
+            expect(item2.isConsumable).toBe(false);
 
             const item3 = new Item({ id: '13', name: 'Consumable String', weight: 10, isConsumable: 'true' }); // truthy string
-            expect(item3.isConsumable).to.be.true;
+            expect(item3.isConsumable).toBe(true);
 
             const item4 = new Item({ id: '14', name: 'Consumable Empty String', weight: 10, isConsumable: '' }); // falsy string
-            expect(item4.isConsumable).to.be.false;
+            expect(item4.isConsumable).toBe(false);
 
             const item5 = new Item({ id: '15', name: 'Packed True', weight: 10, packed: 1 }); // truthy number
-            expect(item5.packed).to.be.true;
+            expect(item5.packed).toBe(true);
 
             const item6 = new Item({ id: '16', name: 'Packed False', weight: 10, packed: 0 }); // falsy number
-            expect(item6.packed).to.be.false;
+            expect(item6.packed).toBe(false);
         });
 
         it('should ensure packIds is an array', () => {
             const item1 = new Item({ id: '17', name: 'PackIds Array', weight: 10, packIds: ['p1'] });
-            expect(item1.packIds).to.deep.equal(['p1']);
+            expect(item1.packIds).toEqual(['p1']);
 
             const item2 = new Item({ id: '18', name: 'PackIds Undefined', weight: 10, packIds: undefined });
-            expect(item2.packIds).to.deep.equal([]);
+            expect(item2.packIds).toEqual([]);
 
             const item3 = new Item({ id: '19', name: 'PackIds Not Array', weight: 10, packIds: 'p1' }); // Should default to empty if not an array
-            expect(item3.packIds).to.deep.equal([]);
+            expect(item3.packIds).toEqual([]);
         });
     });
 });

--- a/test/models/Pack.test.js
+++ b/test/models/Pack.test.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import Pack from '../../models/Pack.js';
 
 describe('Pack Model', () => {
@@ -6,25 +5,25 @@ describe('Pack Model', () => {
         it('should create a pack and assign id and name', () => {
             const packData = { id: 'pack1', name: 'Summer Trip' };
             const pack = new Pack(packData);
-            expect(pack.id).to.equal('pack1');
-            expect(pack.name).to.equal('Summer Trip');
+            expect(pack.id).toBe('pack1');
+            expect(pack.name).toBe('Summer Trip');
         });
 
         it('should handle missing optional fields (though id and name are typically required by services)', () => {
             // Test with only id
             const pack1 = new Pack({ id: 'packOnlyId' });
-            expect(pack1.id).to.equal('packOnlyId');
-            expect(pack1.name).to.be.undefined;
+            expect(pack1.id).toBe('packOnlyId');
+            expect(pack1.name).toBeUndefined();
 
             // Test with only name
             const pack2 = new Pack({ name: 'PackOnlyName' });
-            expect(pack2.id).to.be.undefined;
-            expect(pack2.name).to.equal('PackOnlyName');
+            expect(pack2.id).toBeUndefined();
+            expect(pack2.name).toBe('PackOnlyName');
 
             // Test with empty object
             const pack3 = new Pack({});
-            expect(pack3.id).to.be.undefined;
-            expect(pack3.name).to.be.undefined;
+            expect(pack3.id).toBeUndefined();
+            expect(pack3.name).toBeUndefined();
         });
     });
 });


### PR DESCRIPTION
- Removed Mocha, Chai, and Sinon dependencies.
- Added Jest dependency.
- Updated npm test script to use Jest.
- Migrated existing tests to Jest's assertion syntax.
- Ensured ES Module compatibility for tests.